### PR TITLE
fix: Update zustand peerDependencies/example dependency; Fix test

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0",
-    "zustand": "^4.3.2",
+    "zustand": "^4.3.8",
     "zustand-computed": "file:../"
   },
   "scripts": {

--- a/example/src/App.test.tsx
+++ b/example/src/App.test.tsx
@@ -4,6 +4,6 @@ import App from './App';
 
 test('renders learn react link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/zustand-computed/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -59,6 +59,9 @@ function App() {
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
+        <h1>
+          <a href="https://github.com/chrisvander/zustand-computed">zustand-computed</a>
+        </h1>
         <Counter />
       </header>
     </div>

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -9373,9 +9373,9 @@ yocto-queue@^0.1.0:
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 "zustand-computed@file:..":
-  version "1.3.3"
+  version "1.3.5"
 
-zustand@^4.3.2:
+zustand@^4.3.8:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.8.tgz#37113df8e9e1421b0be1b2dca02b49b76210e7c4"
   integrity sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
-    "zustand": "^4.3.2"
+    "zustand": "^4.3.8"
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "zustand": "^4.1.4"
+    "zustand": "^4.3.8"
   },
   "keywords": [
     "react",

--- a/src/computed.test.ts
+++ b/src/computed.test.ts
@@ -1,5 +1,5 @@
-import { computed, ComputedStateOpts } from "./computed"
 import { create } from "zustand"
+import { computed, ComputedStateOpts } from "./computed"
 
 type Store = {
   count: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -4124,9 +4124,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.2.tgz#bb121fcad84c5a569e94bd1a2695e1a93ba85d39"
-  integrity sha512-rd4haDmlwMTVWVqwvgy00ny8rtti/klRoZjFbL/MAcDnmD5qSw/RZc+Vddstdv90M5Lv6RPgWvm1Hivyn0QgJw==
+zustand@^4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.8.tgz#37113df8e9e1421b0be1b2dca02b49b76210e7c4"
+  integrity sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==
   dependencies:
     use-sync-external-store "1.2.0"


### PR DESCRIPTION
## Production Error
Issue occurs when trying to use `zustand/middleware/immer` with `zustand-computed`:

> Argument of type 'StateCreator<Store & ComputedStore, [], [["zustand/devtools", never], ...[keyof StoreMutators<unknown, unknown>, unknown][]]>' is not assignable to parameter of type 'StateCreator<Store, [], [["zustand/devtools", never], ...[keyof StoreMutators<unknown, unknown>, unknown][]]>'.
  Types of parameters 'getState' and 'getState' are incompatible.
    Type 'Store' is not assignable to type 'Store & ComputedStore'.
      Property 'countSq' is missing in type 'Store' but required in type 'ComputedStore'.ts(2345)
App.tsx(15, 3): 'countSq' is declared here.

Error is also reproduced in [example/src/App.tsx](https://github.com/chrisvander/zustand-computed/blob/main/example/src/App.tsx#L25-L38).

## Steps to resolve:
Deleting the `yarn.lock` file and generating a new file via `yarn install` will resolve the issue, but I'm not sure exactly why it was occurring with the lock file.

While testing, I noticed some `zustand` version inconsistencies and an issue with the `example` test. so updated those as well.

Note: `zustand` upgrade to `4.3.8` is not required to fix, this could be fixed while using `4.3.2` with the steps above. But seemed safe to include those as part of this update.