### PR TITLE
fix: updated setWithComputed by adding the third optional action parameter

### DIFF
--- a/src/computed.ts
+++ b/src/computed.ts
@@ -84,7 +84,7 @@ const computedImpl: ComputedStateImpl = (f, compute, opts) => {
     }
 
     // higher level function to handle compute & compare overhead
-    const setWithComputed = (update: T | ((state: T) => T), replace?: boolean) => {
+    const setWithComputed = (update: T | ((state: T) => T), replace?: boolean, ...a: []) => {
       set((state: T): T & A => {
         const updated = typeof update === "object" ? update : update(state)
 
@@ -94,7 +94,7 @@ const computedImpl: ComputedStateImpl = (f, compute, opts) => {
         }
 
         return computeAndMerge({ ...state, ...updated })
-      }, replace)
+      }, replace, ...a)
     }
 
     const _api = api as Mutate<StoreApi<T>, [["chrisvander/zustand-computed", A]]>


### PR DESCRIPTION
**Issue:** In order to use the redux devtools propperly you have to set the third optional `action` parameter. This allows you to track the action inside of the redux dev tools.

This is currently not passed through and in turn makes the dev tools register the action as 'anonymous' 

<img width="160" alt="Screenshot 2023-11-02 at 2 17 42 pm" src="https://github.com/chrisvander/zustand-computed/assets/101684796/acb73202-48d3-47d7-b032-8c5a83913cad">

Please look at this comment by a zustand contributor as to why I've added this field.

https://github.com/pmndrs/zustand/issues/705#issuecomment-992976936