### PR TITLE
update peerDependencies to support React 18 and 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "zustand": "^5.0.0"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
+    "react": "^18.2.0 || ^19.0.0",
     "zustand": "^5.0.0"
   },
   "exports": {


### PR DESCRIPTION
Hi,

I’ve updated the peerDependencies in package.json to allow support for React 18 and 19 by modifying the version range for React:

Changed from: "react": "^18.2.0"
Changed to: "react": "^18.2.0 || ^19.0.0"
This update ensures compatibility with React 19 while still supporting React 18, providing users with flexibility in their React versions.

Please review and let me know if you'd like any further changes or adjustments.